### PR TITLE
fix: reduzir logs de produção na inicialização de abas

### DIFF
--- a/tabs_init.js
+++ b/tabs_init.js
@@ -6,6 +6,15 @@
 (function () {
   'use strict';
 
+  const DEBUG = false;
+
+  function debug(...args) {
+    if (DEBUG) {
+      // eslint-disable-next-line no-console
+      console.log(...args);
+    }
+  }
+
   if (window.__tabsInitV2Loaded) return;
   window.__tabsInitV2Loaded = true;
 
@@ -40,14 +49,14 @@
   }
 
   async function inicializarAbas() {
-    console.log('🔄 Aguardando carregamento das funções...');
+    debug('🔄 Aguardando carregamento das funções...');
     await esperarFuncoes();
-    console.log('✅ Funções carregadas! Inicializando abas...');
+    debug('✅ Funções carregadas! Inicializando abas...');
 
     // ✅ Inicializar aba Gestão Oficina com data-tab-gestao
     const abaGestaoOficina = document.querySelector('[data-tab-gestao]');
     if (abaGestaoOficina) {
-      console.log('🔍 Botão Gestão Oficina encontrado!');
+      debug('🔍 Botão Gestão Oficina encontrado!');
 
       // Remover onclick inline se existir
       abaGestaoOficina.removeAttribute('onclick');
@@ -57,13 +66,13 @@
         abaGestaoOficina.dataset.boundGestaoTab = '1';
         abaGestaoOficina.addEventListener('click', function (e) {
           e.preventDefault();
-          console.log('👆 Clique na aba Gestão Oficina');
+          debug('👆 Clique na aba Gestão Oficina');
 
           // 1. Trocar de aba
           if (typeof window.switchTab === 'function') {
             window.switchTab('gestao-oficina');
             window.dispatchEvent(new CustomEvent('gestao-oficina:activated'));
-            console.log('✅ Aba trocada para gestao-oficina');
+            debug('✅ Aba trocada para gestao-oficina');
           } else {
             console.error('❌ switchTab não está disponível');
           }
@@ -76,7 +85,7 @@
             // Iniciar Dashboard
             if (typeof window.iniciarDashboardFirestore === 'function') {
               window.iniciarDashboardFirestore();
-              console.log('🔥 Dashboard iniciado!');
+              debug('🔥 Dashboard iniciado!');
             } else {
               console.warn('⚠️ iniciarDashboardFirestore não disponível');
             }
@@ -84,7 +93,7 @@
             // Iniciar Kanban
             if (typeof window.iniciarKanban === 'function') {
               window.iniciarKanban();
-              console.log('🎯 Kanban iniciado!');
+              debug('🎯 Kanban iniciado!');
             } else {
               console.warn('⚠️ iniciarKanban não disponível');
             }
@@ -92,7 +101,7 @@
         });
       }
 
-      console.log('✅ Aba Gestão Oficina inicializada');
+      debug('✅ Aba Gestão Oficina inicializada');
     } else {
       console.error('❌ Botão [data-tab-gestao] não encontrado no DOM');
     }
@@ -112,7 +121,7 @@
             window.abrirModalNovoOS();
           }
         });
-        console.log('✅ Botão Nova OS inicializado');
+        debug('✅ Botão Nova OS inicializado');
       }
     };
 
@@ -126,7 +135,7 @@
       setTimeout(ativarGestaoV2, 50);
     }
 
-    console.log('🎉 Inicialização de abas concluída!');
+    debug('🎉 Inicialização de abas concluída!');
   }
 
   /**
@@ -145,19 +154,19 @@
           // Parar dashboard
           if (typeof window.pararDashboardFirestore === 'function') {
             window.pararDashboardFirestore();
-            console.log('🛑 Dashboard parado');
+            debug('🛑 Dashboard parado');
           }
 
           // Parar kanban
           if (typeof window.pararKanban === 'function') {
             window.pararKanban();
-            console.log('🛑 Kanban parado');
+            debug('🛑 Kanban parado');
           }
         }
       });
     });
 
-    console.log('✅ Interceptador de aba configurado');
+    debug('✅ Interceptador de aba configurado');
   }
 
   window.ativarGestaoV2 = ativarGestaoV2;


### PR DESCRIPTION
### Motivation
- Reduzir ruído no console em produção durante o fluxo de inicialização de abas, mantendo avisos e erros visíveis.

### Description
- Adicionado `const DEBUG = false` e um wrapper `debug(...)` em `tabs_init.js` para centralizar logs informativos.
- Substituídos `console.log` informativos por `debug(...)` nos pontos de inicialização de abas, clique da aba Gestão Oficina, inicialização de Dashboard/Kanban, inicialização do botão Nova OS e interceptação de troca de abas.
- Mantidos `console.warn` e `console.error` para alertas e falhas reais.
- Incluída diretiva `// eslint-disable-next-line no-console` dentro do wrapper para evitar alerta de linter ao usar `console.log` condicionado.

### Testing
- Executado `npx eslint tabs_init.js` — passou.
- Executado `npm test` (rodando `node tests/critical-flows.test.js`) — passou (`critical-flows: ok`).
- Executado `npm run lint -- tabs_init.js` — falhou por erros de lint em arquivos do repositório fora do escopo desta mudança, não relacionados a `tabs_init.js`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a1e51372488329b8d9121ace6459e3)